### PR TITLE
Fix | Remove Shapeways

### DIFF
--- a/components/SocialMediaLinks.tsx
+++ b/components/SocialMediaLinks.tsx
@@ -12,19 +12,20 @@ const socialMedia = [
     name: "GitHub",
     icon: Icons.GitHub,
     url: "https://github.com/zacharyschaffter",
-    description: "Go ahead, creep on my code",
+    description: "",
   },
-  {
-    name: "Shapeways",
-    icon: Icons.Shapeways,
-    url: "https://www.shapeways.com/shops/robozack",
-    description: "Some of my 3D Prints",
-  },
+  // Shapeways went bankrupt, so is no longer a valid platform
+  // {
+  //   name: "Shapeways",
+  //   icon: Icons.Shapeways,
+  //   url: "https://www.shapeways.com/shops/robozack",
+  //   description: "Some of my 3D Prints",
+  // },
   {
     name: "LinkedIn",
     icon: Icons.LinkedIn,
     url: "https://www.linkedin.com/in/zachary-schaffter/",
-    description: "Let's connect!",
+    description: "Let's connect, just don't expect me to post",
   },
 ];
 

--- a/icons/index.tsx
+++ b/icons/index.tsx
@@ -102,11 +102,3 @@ export const LinkedIn: IconComponent = ({ color }) => (
     </g>
   </svg>
 );
-
-export default {
-  Logo,
-  CodePen,
-  GitHub,
-  LinkedIn,
-  Shapeways,
-};


### PR DESCRIPTION
Shapeways as a platform went bankrupt, closing down all creator shops.  With my 3D models added to my site, I can remove the social media link out (which is currently just going to a Shapeways blog article explaining their shutdown/acquisition)